### PR TITLE
Fix Snyk Compatibility

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
-import setuptools
+from setuptools import setup
 
-setuptools.setup(
+setup(
     name="opentelemetry-ext-newrelic",
     use_scm_version={
         "write_to": "src/opentelemetry_ext_newrelic/version.py",


### PR DESCRIPTION
Snyk has a bug where it could not read previous `setup.py` file. Fixed by changing import strategy.

Sidekick: @umaannamalai 